### PR TITLE
Included a package in the String.kt file

### DIFF
--- a/medeia-validator-core/src/main/kotlin/com/worldturner/util/String.kt
+++ b/medeia-validator-core/src/main/kotlin/com/worldturner/util/String.kt
@@ -1,3 +1,5 @@
+package com.worldturner.util
+
 import java.net.URLEncoder
 import java.nio.charset.Charset
 

--- a/medeia-validator-core/src/main/kotlin/com/worldturner/util/Uri.kt
+++ b/medeia-validator-core/src/main/kotlin/com/worldturner/util/Uri.kt
@@ -1,6 +1,5 @@
 package com.worldturner.util
 
-import replaceFromLast
 import java.net.URI
 
 fun URI.hasAnyOtherThanFragment() =


### PR DESCRIPTION
Your library is really awesome and I really want to use it from a Java based application but I'm stuck with a problem that I cannot work-around.  My application is modular (Java 17, gradle build system, jlinked) so it's quite strict about importing stuff.

Essentially I get the following error:

> java.lang.module.FindException: Unable to derive module descriptor for /.../medeia-validator-core-1.1.1-module.jar
> Caused by: java.lang.module.InvalidModuleDescriptorException: StringKt.class found in top-level directory (unnamed package not allowed in module)

I think this is very easy to resolve by simply adding a `package` statement to the `medeia-validator-core/src/main/kotlin/com/worldturner/util/String.kt` file as I've done here (and the knock-on of that is that you can remove an `import` statement elsewhere).

I notice all the other files in that `util` directory already have the `package` statement and once I apply this change it all works wonderfully.


